### PR TITLE
Fix for dataclass field initialization

### DIFF
--- a/goodai/ltm/mem/config.py
+++ b/goodai/ltm/mem/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, List, Any
 
@@ -111,7 +111,8 @@ class TextMemoryConfig:
     redundant if it overlaps with other passages that are a better match to a query.
     """
 
-    chunk_expansion_config: ChunkExpansionConfig = ChunkExpansionConfig(24)
+    chunk_expansion_config: ChunkExpansionConfig = field(
+        default_factory=ChunkExpansionConfig)
     """
     The chunk expansion configuration.
     """


### PR DESCRIPTION
Python 3.11+ complains that mutable field needs to use default_factory to initialize value.